### PR TITLE
Port errors to thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,11 +468,11 @@ dependencies = [
 name = "fxrecorder"
 version = "0.1.0"
 dependencies = [
- "derive_more",
  "libfxrecord",
  "serde",
  "slog",
  "structopt",
+ "thiserror",
  "tokio",
  "toml",
 ]
@@ -1408,6 +1408,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,6 +734,7 @@ dependencies = [
  "slog-async",
  "slog-term",
  "structopt",
+ "thiserror",
  "tokio",
  "tokio-serde",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,6 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "async-trait",
- "derive_more",
  "futures",
  "libfxrecord",
  "mockito",
@@ -493,6 +492,7 @@ dependencies = [
  "slog",
  "structopt",
  "tempfile",
+ "thiserror",
  "tokio",
  "toml",
  "url",

--- a/fxrecorder/Cargo.toml
+++ b/fxrecorder/Cargo.toml
@@ -14,10 +14,10 @@ name = "fxrecorder"
 path = "src/bin/main.rs"
 
 [dependencies]
-derive_more = "0.99.7"
 libfxrecord = { path = "../libfxrecord" }
 serde = { version = "1.0.110", features = ["derive"] }
 slog = "2.5.2"
 structopt = "0.3.14"
+thiserror = "1.0.20"
 tokio = { version = "0.2.21", features = ["tcp", "rt-threaded", "time"] }
 toml = "0.5.6"

--- a/fxrecorder/src/lib/retry.rs
+++ b/fxrecorder/src/lib/retry.rs
@@ -6,11 +6,11 @@ use std::error::Error;
 use std::future::Future;
 use std::time::Duration;
 
-use derive_more::Display;
+use thiserror::Error;
 use tokio::time::delay_for;
 
-#[derive(Debug, Display)]
-#[display(fmt = "failed after {} retries", retries)]
+#[derive(Debug, Error)]
+#[error("failed after {} retries", retries)]
 /// An error that occurred when retrying a fallable operation.
 pub struct RetryError<E: Error + 'static> {
     /// The last error that occurred.
@@ -18,12 +18,6 @@ pub struct RetryError<E: Error + 'static> {
 
     /// The number of retries.
     retries: u32,
-}
-
-impl<E: Error + 'static> Error for RetryError<E> {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        Some(&self.source)
-    }
 }
 
 /// Attempt to resolve the future returned by the given function `retries` times

--- a/fxrunner/Cargo.toml
+++ b/fxrunner/Cargo.toml
@@ -15,7 +15,6 @@ path = "src/bin/main.rs"
 
 [dependencies]
 async-trait = "0.1.36"
-derive_more = "0.99.7"
 futures = "0.3.5"
 libfxrecord = { path = "../libfxrecord" }
 reqwest =  { version = "0.10.6", features = ["json"] }
@@ -27,6 +26,7 @@ tokio = { version = "0.2.21", features = ["blocking", "fs", "macros", "io-util",
 toml = "0.5.6"
 url = "2.1.1"
 zip = "0.5.6"
+thiserror = "1.0.20"
 
 [dependencies.winapi]
 git =  "https://github.com/retep998/winapi-rs"

--- a/fxrunner/src/lib/osapi/error.rs
+++ b/fxrunner/src/lib/osapi/error.rs
@@ -2,13 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::error::Error;
 use std::ffi::CString;
 use std::mem::forget;
 use std::ptr::{null, null_mut};
 
-use derive_more::Display;
 use libfxrecord::error::ErrorMessage;
+use thiserror::Error;
 use winapi::shared::minwindef::{DWORD, HLOCAL};
 use winapi::shared::ntdef::{LANG_NEUTRAL, LPSTR, MAKELANGID, SUBLANG_DEFAULT};
 use winapi::um::errhandlingapi::GetLastError;
@@ -20,23 +19,23 @@ use winapi::um::winbase::{
 /// An error from Windows.
 ///
 /// The error will be formatted with `FormatMessageA` if possible.
-#[derive(Debug, Display)]
+#[derive(Debug, Error)]
+#[error("{}", .0)]
 pub struct WindowsError(WindowsErrorImpl);
 
-impl Error for WindowsError {}
-
-#[derive(Debug, Display)]
+#[derive(Debug, Error)]
 enum WindowsErrorImpl {
-    #[display(
-        fmt = "An error occurred {:X}. Additionally, we could not format the error with FormatMessageA: {:X}.",
-        error_code,
-        format_error_code
+    #[error(
+        "An error occurred {:X}. Additionally, we could not format the error with FormatMessageA: {:X}.",
+        .error_code,
+        .format_error_code
     )]
     FormatMessageFailed {
         error_code: DWORD,
         format_error_code: DWORD,
     },
 
+    #[error(transparent)]
     Message(ErrorMessage<String>),
 }
 

--- a/fxrunner/src/lib/osapi/perf.rs
+++ b/fxrunner/src/lib/osapi/perf.rs
@@ -2,12 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::error::Error;
 use std::ffi::CString;
 use std::ptr::null_mut;
 use std::u32;
 
-use derive_more::Display;
+use thiserror::Error;
 use winapi::shared::minwindef::FILETIME;
 use winapi::um::fileapi::{CreateFileA, OPEN_EXISTING};
 use winapi::um::ioapiset::DeviceIoControl;
@@ -24,26 +23,20 @@ pub struct IoCounters {
     pub writes: u32,
 }
 
-#[derive(Debug, Display)]
+#[derive(Debug, Error)]
 enum DiskIoErrorKind {
-    #[display(fmt = "could not open C:\\ drive")]
+    #[error("could not open C:\\ drive")]
     NoLogicalCDrive,
 
-    #[display(fmt = "could not retrieve IO counters for C:\\ drive")]
+    #[error("could not retrieve IO counters for C:\\ drive")]
     IoCounterError,
 }
 
-#[derive(Debug, Display)]
-#[display(fmt = "{}: {}", kind, source)]
+#[derive(Debug, Error)]
+#[error("{}: {}", .kind, .source)]
 pub struct DiskIoError {
     kind: DiskIoErrorKind,
     source: WindowsError,
-}
-
-impl Error for DiskIoError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        Some(&self.source)
-    }
 }
 
 pub(super) fn get_disk_io_counters() -> Result<IoCounters, DiskIoError> {

--- a/fxrunner/src/lib/zip.rs
+++ b/fxrunner/src/lib/zip.rs
@@ -2,12 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::error::Error;
 use std::fs::{create_dir_all, File};
 use std::io;
 use std::path::{Path, PathBuf};
 
-use derive_more::Display;
+use thiserror::Error;
 use zip::ZipArchive;
 
 /// Statistics about an unzip operation.
@@ -101,29 +100,29 @@ fn common_stem(p1: &Path, p2: &Path) -> Option<PathBuf> {
     common
 }
 
-#[derive(Debug, Display)]
+#[derive(Debug, Error)]
 pub enum ZipError {
-    #[display(
-        fmt = "Could not open zip archive `{}': {}",
-        "archive.display()",
-        source
+    #[error(
+        "Could not open zip archive `{}': {}",
+        .archive.display(),
+        .source
     )]
     OpenArchive { archive: PathBuf, source: io::Error },
 
-    #[display(
-        fmt = "could not read zip archive `{}': {}",
-        "archive.display()",
-        source
+    #[error(
+        "could not read zip archive `{}': {}",
+        .archive.display(),
+        .source
     )]
     ReadArchive {
         archive: PathBuf,
         source: zip::result::ZipError,
     },
 
-    #[display(
-        fmt = "IO error while extracting file `{}' from archive `{}': {}",
-        "file_name.display()",
-        "archive.display()",
+    #[error(
+        "IO error while extracting file `{}' from archive `{}': {}",
+        .file_name.display(),
+        .archive.display(),
         source
     )]
     Io {
@@ -132,23 +131,12 @@ pub enum ZipError {
         source: io::Error,
     },
 
-    #[display(
-        fmt = "could not make required directory `{}': {}",
-        "path.display()",
-        source
+    #[error(
+        "could not make required directory `{}': {}",
+        .path.display(),
+        .source
     )]
     MakeDir { path: PathBuf, source: io::Error },
-}
-
-impl Error for ZipError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            ZipError::OpenArchive { ref source, .. } => Some(source),
-            ZipError::ReadArchive { ref source, .. } => Some(source),
-            ZipError::Io { ref source, .. } => Some(source),
-            ZipError::MakeDir { ref source, .. } => Some(source),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/libfxrecord/Cargo.toml
+++ b/libfxrecord/Cargo.toml
@@ -14,6 +14,7 @@ slog = "2.5.2"
 slog-async = "2.5.0"
 slog-term = "2.5.0"
 structopt = "0.3.14"
+thiserror = "1.0.20"
 toml = "0.5.6"
 tokio = { version = "0.2.21", features = ["tcp", "macros"] }
 tokio-util = { version = "0.3.1", features = ["codec"] }

--- a/libfxrecord/src/net/message.rs
+++ b/libfxrecord/src/net/message.rs
@@ -81,11 +81,11 @@
 //! [impl_message]: ../../macro.impl_message.html
 
 use std::convert::TryFrom;
-use std::error::Error;
 use std::fmt::{Debug, Display};
 
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::error::ErrorMessage;
 use crate::prefs::PrefValue;
@@ -111,18 +111,16 @@ where
 }
 
 /// An error that occurs when attempting to extract a message variant.
-#[derive(Debug, Display)]
-#[display(
-    fmt = "could not convert message of kind `{}' to kind `{}'",
-    expected,
-    actual
+#[derive(Debug, Error)]
+#[error(
+    "could not convert message of kind `{}' to kind `{}'",
+    .expected,
+    .actual
 )]
 pub struct KindMismatch<K: Debug + Display> {
     pub expected: K,
     pub actual: K,
 }
-
-impl<K: Debug + Display> Error for KindMismatch<K> {}
 
 /// Generate an inner message type.
 ///

--- a/libfxrecord/src/prefs.rs
+++ b/libfxrecord/src/prefs.rs
@@ -3,12 +3,11 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::convert::{TryFrom, TryInto};
-use std::error::Error;
 use std::io;
 
-use derive_more::Display;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use thiserror::Error;
 use tokio::prelude::*;
 
 /// The value of a pref.
@@ -19,37 +18,22 @@ pub struct PrefValue(Value);
 
 /// An error from attemtpting to coerce a `Value` into a
 /// [`PrefValue`](struct.PrefValue.html).
-#[derive(Debug, Display)]
+#[derive(Debug, Error)]
 pub enum PrefError {
-    #[display(fmt = "Pref values cannot be null")]
+    #[error("Pref values cannot be null")]
     Null,
 
-    #[display(fmt = "Pref values cannot be arrays")]
+    #[error("Pref values cannot be arrays")]
     Array,
 
-    #[display(fmt = "Pref values cannot be objects")]
+    #[error("Pref values cannot be objects")]
     Object,
 
-    #[display(fmt = "Expected a colon (`:') while parsing a pref")]
+    #[error("Expected a colon (`:') while parsing a pref")]
     ExpectedColon,
 
-    #[display(fmt = "Could not parse pref: {}", _0)]
-    Json(serde_json::Error),
-}
-
-impl Error for PrefError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            PrefError::Json(ref e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl From<serde_json::Error> for PrefError {
-    fn from(e: serde_json::Error) -> Self {
-        PrefError::Json(e)
-    }
+    #[error("Could not parse pref: {}", _0)]
+    Json(#[from] serde_json::Error),
 }
 
 impl TryFrom<Value> for PrefValue {


### PR DESCRIPTION
This PR updates all of our error implementations to use the `thiserror` crate, which adds a `derive(Error)` macro. This macro will automatically generate the `Display` and `Error` impls, as well as any `From` impls.