### PR TITLE
Rewrite `impl_message!` as a proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,7 @@ dependencies = [
  "derive_more",
  "futures",
  "indoc",
+ "libfxrecord_macros",
  "serde",
  "serde_json",
  "slog",
@@ -741,6 +742,18 @@ dependencies = [
  "tokio-serde",
  "tokio-util",
  "toml",
+]
+
+[[package]]
+name = "libfxrecord_macros"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "libfxrecord",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
 ]
 
 [[package]]
@@ -1360,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.31"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
+checksum = "936cae2873c940d92e697597c5eee105fb570cd5689c695806f672883653349b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@ members = [
     "fxrecorder",
     "fxrunner",
     "libfxrecord",
+    "libfxrecord_macros",
     "integration-tests",
 ]

--- a/libfxrecord/Cargo.toml
+++ b/libfxrecord/Cargo.toml
@@ -8,6 +8,7 @@ license = "MPL-2.0"
 [dependencies]
 derive_more = "0.99.7"
 futures = "0.3.5"
+libfxrecord_macros = { path = "../libfxrecord_macros" }
 serde = { version = "1.0.110", features = ["derive"] }
 serde_json = "1.0.55"
 slog = "2.5.2"

--- a/libfxrecord/src/net/message.rs
+++ b/libfxrecord/src/net/message.rs
@@ -4,98 +4,19 @@
 
 //! Message types used throughout `fxrunner` and `fxrecorder`.
 //!
-//! This module consists of various helper traits and structures, as well as
-//! the [`impl_message!`][impl_message] macro, which together provide a
-//! convenient way for [`Proto`][Proto] instances to send and receive typed
-//! messages at a high level.
+//! This module consists of various helper traits and structures, which when
+//! combined with the [`message_type!`][message_type] macro from the
+//! `libfxrecord_macros` crate, provide a convient way for [`Proto`][Proto]
+//! instances to send and receive typed messages at a high level.
 //!
-//! Each invocation of [`impl_message!`][impl_message] will generate several types:
-//!
-//! 1. The message type. This is a wrapper enum type that contains all message
-//!    variants. It is the type that is serialized/deserialized by the
-//!    [`Proto`][Proto]. It will also implement the [`Message`][Message] so that
-//!    its variants can be differentiated by the message kind type.
-//!
-//!    For example, for this invocation of [`impl_message!`][impl_message]
-//!
-//!    ```ignore
-//!    impl_message! {
-//!        /// The message type.
-//!        Msg,
-//!        /// The message kind enumeration.
-//!        MsgKind;
-//!        /// A message without any fields.
-//!        ///
-//!        /// This is the most simple kind of message.
-//!        FooMsg;
-//!
-//!        /// A "Bar msg"
-//!        ///
-//!        /// This message has a field.
-//!        BarMsg {
-//!            /// The contents of the message.
-//!            ///
-//!            /// The type of this field is `u32`.
-//!            field: u32,
-//!        };
-//!    }
-//!    ```
-//!
-//!    the following message type would be generated:
-//!
-//!    ```ignore
-//!    pub enum Msg {
-//!        FooMsg(FooMsg),
-//!        BarMsg(BarMsg),
-//!    }
-//!
-//!    impl Message<'_> for Msg { /* ... */ }
-//!    ```
-//!
-//!    Here `FooMsg` and `BarMsg` will be generated structures containing actual
-//!    message data.
-//!
-//! 2. A message kind type. This is an enum with one variant for each kind of message.
-//!
-//!    For example, for the same invocation of `impl_message!` as before, the
-//!    following kind type would be generated:
-//!
-//!    ```ignore
-//!    pub enum MsgKind {
-//!        FooMsg,
-//!        BarMsg,
-//!    }
-//!    ```
-//!
-//! 3. Message content types for each message.
-//!
-//!    In the example above, this is the `FooMsg` and `BarMsg` structures. The
-//!    following would be generated for that invocation:
-//!
-//!    ```ignore
-//!     pub struct FooMsg;
-//!
-//!     pub struct BarMsg {
-//!         pub enum field: u32,
-//!     }
-//!     ```
-//!
-//!     as well as implementations for [`MessageContent`][MessageContent] and
-//!     conversion traits.
-//!
-//!     These are the concrete message types that
-//!     [`Proto::recv_kind`][Proto::recv_kind] will receive.
-//!
-//! [Proto]: ../proto/struct.Proto.html
-//! [Proto::recv_kind]: ../proto/struct.Proto.html#fn.recv_kind
-//! [Message]: trait.Message.html
-//! [MessageContent]: trait.MessageContent.html
-//! [impl_message]: ../../macro.impl_message.html
+//! [Proto]: ./struct.Proto.html
+//! [message_type]: ../../../libfxrecord_macros/macro.message_type.html
 
 use std::convert::TryFrom;
 use std::fmt::{Debug, Display};
 
 use derive_more::Display;
+use libfxrecord_macros::message_type;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -132,211 +53,6 @@ where
 pub struct KindMismatch<K: Debug + Display> {
     pub expected: K,
     pub actual: K,
-}
-
-/// Generate an inner message type.
-///
-/// The generated type will either be a unit struct or a non-empty struct with
-/// named fields.
-#[macro_export] // Only exported for doctests.
-macro_rules! impl_message_inner {
-    // Generate a unit struct.
-    (
-        $(#[doc = $doc:expr])*
-        $name:ident
-    ) => {
-        $(#[doc = $doc])*
-        #[derive(Debug, Deserialize, Serialize)]
-        pub struct $name;
-    };
-
-    // Generate a struct with named fields.
-    (
-        $(#[doc = $doc:expr])*
-        $name:ident {
-        $(
-            $(#[doc = $field_doc:expr])*
-            $field:ident : $field_ty:ty,
-        )*
-    }) => {
-        $(#[doc = $doc])*
-        #[derive(Debug, Deserialize, Serialize)]
-        pub struct $name {
-            $(
-                $(#[doc = $field_doc])?
-                pub $field: $field_ty,
-            )*
-        }
-    };
-}
-
-/// Generate messages and their implementations.
-///
-/// The first argument is the name of the message type. This will generate a
-/// wrapper enum with this name that contains tuple variants for each named message.
-///
-/// The second argument is the name of the message kind type. This will generate
-/// an enum with unit variants for each named message.
-///
-/// The rest of the arguments are the message variants, which will generate both
-/// an enum variant in the message type and a standalone struct.
-///
-/// Doc-comments applied to items are persisted.
-///
-/// This will take a macro of the form:
-///
-/// ```
-/// # #[macro_use] extern crate libfxrecord;
-/// # use std::convert::{TryFrom, TryInto};
-/// # use derive_more::Display;
-/// # use serde::{Serialize, Deserialize};
-/// # use libfxrecord::net::message::*;
-/// impl_message! {
-///     Msg,
-///     MsgKind;
-///     FooMsg;
-///     BarMsg {
-///         field: u32,
-///     };
-/// }
-///
-/// # let _m: FooMsg = Msg::FooMsg(FooMsg).try_into().unwrap();
-/// # assert_eq!(FooMsg::kind(), MsgKind::FooMsg);
-/// # assert_eq!(Msg::FooMsg(FooMsg).kind(), MsgKind::FooMsg);
-/// #
-/// # let _m: BarMsg = Msg::BarMsg(BarMsg { field: 1 }).try_into().unwrap();
-/// # assert_eq!(BarMsg::kind(), MsgKind::BarMsg);
-/// # assert_eq!(Msg::BarMsg(BarMsg { field: 1 }).kind(), MsgKind::BarMsg);
-/// ```
-///
-/// and generate:
-///
-/// ```ignore
-/// pub enum MsgKind {
-///     FooMsg,
-///     BarMsg,
-/// }
-///
-/// pub enum Msg {
-///     FooMsg(FooMsg),
-///     BarMsg(BarMsg),
-/// }
-///
-/// pub struct FooMsg;
-///
-/// pub struct BarMsg {
-///     pub field: u32,
-/// }
-///
-/// impl Message for Msg {
-///     type Kind = MsgKind;
-///
-///     fn kind(&self) -> MsgKind {
-///         match self {
-///             Msg::FooMsg(..) => MsgKind::FooMsg,
-///             Msg::BarMsg(..) => MsgKind::BarMsg,
-///         }
-///     }
-/// }
-///
-/// impl Into<Msg> for FooMsg { /* ... */ }
-/// impl TryFrom<Msg> for FooMsg { /* ... */ }
-/// impl MessageContent<'_, Msg, MsgKind> for FooMsg { /* ... */ }
-///
-/// impl TryFrom<Msg> for BarMsg { /*... */ }
-/// impl Into<Msg> for BarMsg { /* ... */ }
-/// impl MessageContent<'_, Msg, MsgKind> for BarMsg { /* ... */ }
-/// ```
-#[macro_export] // Only exported for doctests.
-macro_rules! impl_message {
-    (
-        $(#[doc = $msg_doc:expr])*
-        $msg_ty:ident,
-
-        $(#[doc = $kind_doc:expr])*
-        $kind_ty:ident;
-
-        $(
-            $(#[doc = $inner_ty_doc:expr])*
-            $inner_ty:ident $({
-                $(
-                    $(#[doc = $field_doc:expr])*
-                    $field:ident: $field_ty:ty,
-                )*
-            })?;
-        )*
-    ) => {
-        $(#[doc = $kind_doc])*
-        #[derive(Clone, Copy, Debug, Display, Eq, PartialEq)]
-        pub enum $kind_ty {
-            $(
-
-                $(#[doc = $inner_ty_doc])*
-                $inner_ty,
-            )*
-        }
-
-        $(#[doc = $msg_doc])*
-        #[derive(Debug, Deserialize, Serialize)]
-        pub enum $msg_ty {
-            $(
-                $(#[doc = $inner_ty_doc])*
-                $inner_ty($inner_ty),
-            )*
-        }
-
-        impl Message<'_> for $msg_ty {
-            type Kind = $kind_ty;
-
-            fn kind(&self) -> Self::Kind {
-                match self {
-                    $(
-                        $msg_ty::$inner_ty(..) => $kind_ty::$inner_ty,
-                    )*
-                }
-            }
-        }
-
-        $(
-            impl_message_inner! {
-                $(#[doc = $inner_ty_doc])*
-                $inner_ty $({
-                    $(
-                        $(#[doc = $field_doc])*
-                        $field: $field_ty,
-                    )*
-                })?
-            }
-
-            impl From<$inner_ty> for $msg_ty {
-                fn from(m: $inner_ty) -> Self {
-                    $msg_ty::$inner_ty(m)
-                }
-            }
-
-            impl TryFrom<$msg_ty> for $inner_ty {
-                type Error = KindMismatch<$kind_ty>;
-
-                fn try_from(msg: $msg_ty) -> Result<Self, Self::Error> {
-                    #[allow(irrefutable_let_patterns)]
-                    if let $msg_ty::$inner_ty(msg) = msg {
-                        Ok(msg)
-                    } else {
-                        Err(KindMismatch {
-                            expected: $kind_ty::$inner_ty,
-                            actual: msg.kind(),
-                        })
-                    }
-                }
-            }
-
-            impl MessageContent<'_, $msg_ty, $kind_ty> for $inner_ty {
-                fn kind() -> $kind_ty {
-                    $kind_ty::$inner_ty
-                }
-            }
-        )*
-    };
 }
 
 /// A request from the recorder to the runner.
@@ -403,19 +119,6 @@ pub struct ResumeRequest {
     pub idle: Idle,
 }
 
-impl_message! {
-    /// A message from FxRecorder to FxRunner.
-    RecorderMessage,
-
-    /// The kind of a [`RecorderMessage`](struct.RecorderMessage.html).
-    RecorderMessageKind;
-
-    /// A request from the recorder to the runner.
-    Request {
-        request: RecorderRequest,
-    };
-}
-
 #[derive(Debug, Display, Eq, PartialEq, Serialize, Deserialize)]
 pub enum DownloadStatus {
     Downloading,
@@ -436,7 +139,20 @@ impl DownloadStatus {
 
 pub type ForeignResult<T> = Result<T, ErrorMessage<String>>;
 
-impl_message! {
+message_type! {
+    /// A message from FxRecorder to FxRunner.
+    RecorderMessage,
+
+    /// The kind of a [`RecorderMessage`](struct.RecorderMessage.html).
+    RecorderMessageKind;
+
+    /// A request from the recorder to the runner.
+    pub struct Request {
+        pub request: RecorderRequest,
+    }
+}
+
+message_type! {
     /// A message from FxRunner to FxRecorder.
     RunnerMessage,
 
@@ -444,43 +160,43 @@ impl_message! {
     RunnerMessageKind;
 
     /// The status of the DownloadBuild phase.
-    DownloadBuild {
-        result: ForeignResult<DownloadStatus>,
-    };
+    pub struct DownloadBuild {
+        pub result: ForeignResult<DownloadStatus>,
+    }
 
     /// The status of the RecvProfile phase.
-    RecvProfile {
-        result: ForeignResult<DownloadStatus>,
-    };
+    pub struct RecvProfile {
+        pub result: ForeignResult<DownloadStatus>,
+    }
 
     /// The result of the CreateProfile phase.
-    CreateProfile {
-        result: ForeignResult<()>,
-    };
+    pub struct CreateProfile {
+        pub result: ForeignResult<()>,
+    }
 
     /// The status of the WritePrefs phase.
-    WritePrefs {
-        result: ForeignResult<()>,
-    };
+    pub struct WritePrefs {
+        pub result: ForeignResult<()>,
+    }
 
     /// The status of the Restarting phase.
-    Restarting {
-        result: ForeignResult<()>,
-    };
+    pub struct Restarting {
+        pub result: ForeignResult<()>,
+    }
 
     /// The status of the NewRequest phase.
-    NewRequestResponse {
+    pub struct NewRequestResponse {
         /// The request ID to be given in a `ResumeRequest`.
-        request_id: ForeignResult<String>,
-    };
+        pub request_id: ForeignResult<String>,
+    }
 
     /// The status of the ResumeResponse phase.
-    ResumeResponse {
-        result: ForeignResult<()>,
-    };
+    pub struct ResumeResponse {
+        pub result: ForeignResult<()>,
+    }
 
     /// The status of the WaitForIdle phase.
-    WaitForIdle {
-        result: ForeignResult<()>,
-    };
+    pub struct WaitForIdle {
+        pub result: ForeignResult<()>,
+    }
 }

--- a/libfxrecord_macros/Cargo.toml
+++ b/libfxrecord_macros/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "libfxrecord_macros"
+version = "0.1.0"
+authors = ["Barret Rennie <barret@brennie.ca>"]
+edition = "2018"
+license = "MPL-2.0"
+
+[lib]
+proc_macro = true
+
+[dependencies]
+proc-macro2 = "1.0.18"
+quote = "1.0.7"
+syn = { version = "1.0.34", features = ["full"] }
+
+[dev-dependencies]
+derive_more = "0.99.7"
+libfxrecord = { path = "../libfxrecord" }
+serde = { version = "1.0.110", features = ["derive"] }

--- a/libfxrecord_macros/src/lib.rs
+++ b/libfxrecord_macros/src/lib.rs
@@ -1,0 +1,365 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/
+
+extern crate proc_macro;
+
+use quote::{quote, ToTokens};
+use syn::parse::{Parse, ParseStream};
+use syn::{parse_quote, Attribute, Ident, ItemEnum, ItemStruct, Meta, Token};
+
+/// Generate message types and implementations.
+///
+/// Example:
+/// ```
+/// # extern crate libfxrecord;
+/// # #[macro_use] extern crate libfxrecord_macros;
+/// #
+/// # use std::convert::TryFrom;
+/// #
+/// # use derive_more::Display;
+/// # use libfxrecord::net::{KindMismatch, Message, MessageContent};
+/// # use serde::{Deserialize, Serialize};
+/// #
+/// message_type! {
+///     # #[derive(Eq, PartialEq)]
+///     MessageType,
+///     MessageKind;
+///
+///     # #[derive(Clone, Copy, Eq, PartialEq)]
+///     pub struct StructVariant {
+///         pub field: i32,
+///     }
+///
+///     # #[derive(Clone, Copy, Eq, PartialEq)]
+///     pub enum EnumVariant {
+///         Foo(char),
+///         Bar(bool),
+///     }
+/// }
+/// # let s = StructVariant { field: 123 };
+/// # let e = EnumVariant::Foo('A');
+/// # assert_eq!(StructVariant::kind(), MessageKind::StructVariant);
+/// # assert_eq!(EnumVariant::kind(), MessageKind::EnumVariant);
+/// # assert_eq!(MessageType::StructVariant(s).kind(), MessageKind::StructVariant);
+/// # assert_eq!(MessageType::EnumVariant(e).kind(), MessageKind::EnumVariant);
+/// #
+/// # assert_eq!(MessageType::from(s), MessageType::StructVariant(s));
+/// # assert_eq!(MessageType::from(e), MessageType::EnumVariant(e));
+/// #
+/// # assert_eq!(StructVariant::try_from(MessageType::StructVariant(s)).unwrap(), s);
+/// # assert_eq!(EnumVariant::try_from(MessageType::EnumVariant(e)).unwrap(), e);
+/// #
+/// # assert!(StructVariant::try_from(MessageType::EnumVariant(e)).is_err());
+/// # assert!(EnumVariant::try_from(MessageType::StructVariant(s)).is_err());
+/// ```
+///
+/// This macro generates several items:
+///
+/// 1. The message type. This is a wrapper enum that contains all message
+///    variants. It is the type that is serialized/deserialized by the
+///    [`Proto`][Proto]. It will also implement the [`Message`][Message] trait so
+///    that its variants can be differentiated by the message kind type.
+///
+///    In the above example, this is the `MessageType`. The following type would be
+///    generated:
+///    ```
+///    # type StructVariant = (); // Omitted.
+///    # type EnumVariant = (); // Omittd.
+///    pub enum MessageType {
+///        StructVariant(StructVariant),
+///        EnumVariant(EnumVariant),
+///    }
+///    ```
+///
+/// 2. A message kind type. This is an enum with one variant for each kind of
+///    message. This kind is used to differentiate between various messages that are
+///    part of the same message enum.
+///
+///    In the above example, this is `MessageKind`. For that example, the following
+///    type would be generated:
+///    ```
+///    pub enum MessageKind {
+///        StructVariant,
+///        EnumVariant,
+///    }
+///
+/// 3. Message content types for each message.
+///
+///    In the above example, these are `StructVariant` and `EnumVariant`. They are
+///    emitted verbatim as they are in the macro input. For example, the following
+///    types would be emitted for the above example:
+///
+///    ```
+///     pub struct StructVariant {
+///         pub field: i32,
+///     }
+///
+///     pub enum EnumVariant {
+///         Foo(f32),
+///         Bar(String),
+///     }
+///     ```
+///
+/// 4. Implementations of [`MessageContent`][MessageContent] for each variant,
+///    tying it to its `MessageType` and `MessageKind`.
+///
+/// 5. Conversion traits between the variants and the message type.
+///
+///    For each variant, the following impls are emitted:
+///    * [`From<Variant> for MessageType`][From]
+///    * [`TryFrom<MessageType> for Variant`][TryFrom].
+///
+/// [Proto]: ../libfxrecord/net/proto/struct.Proto.html
+/// [Message]: ../libfxrecord/net/message/trait.Message.html
+/// [MessageContent]: ../libfxrecord/net/message/trait.MessageContent.html
+/// [From]: https://doc.rust-lang.org/std/convert/trait.From.html
+/// [TryFrom]: https://doc.rust-lang.org/std/convert/trait.TryFrom.html
+#[proc_macro]
+pub fn message_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let decl = match syn::parse::<MessageDecl>(input) {
+        Ok(decl) => decl,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    let msg_kind = generate_message_kind_type(&decl);
+    let msg_ty = generate_message_type(&decl);
+    let variant = &decl.variants;
+    let impls = generate_impls(&decl);
+
+    let tokens = quote! {
+        #msg_kind
+        #msg_ty
+        #(
+            #[derive(Debug, Deserialize, Serialize)]
+            #variant
+        )*
+        #impls
+    };
+
+    tokens.into()
+}
+
+/// The body of the `message_type!{}` macro.
+struct MessageDecl {
+    /// The type declaration for the message enumeration.
+    msg_ty: TyDecl,
+    _comma: Token![,],
+    /// The type declaration for the message kind enumeration.
+    kind_ty: TyDecl,
+    _semi: Token![;],
+    /// The message variants.
+    variants: Vec<VariantDecl>,
+}
+
+impl Parse for MessageDecl {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(MessageDecl {
+            msg_ty: input.parse()?,
+            _comma: input.parse()?,
+            kind_ty: input.parse()?,
+            _semi: input.parse()?,
+            variants: {
+                let mut variants = vec![];
+                loop {
+                    variants.push(input.parse()?);
+                    if input.is_empty() {
+                        break variants;
+                    }
+                }
+            },
+        })
+    }
+}
+
+/// A type declaration.
+struct TyDecl {
+    /// Attributes (e.g., doc comments) for the type.
+    attrs: Vec<Attribute>,
+    /// The name of the type to be declared.
+    ident: Ident,
+}
+
+impl Parse for TyDecl {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(TyDecl {
+            attrs: Attribute::parse_outer(input)?,
+            ident: input.parse()?,
+        })
+    }
+}
+
+/// A message variant.
+struct VariantDecl {
+    /// The outer attributes of the variant.
+    ///
+    /// These are likely entirely doc comments.
+    attrs: Vec<Attribute>,
+
+    /// The struct or enum item representing the variant.
+    inner: VariantDeclInner,
+}
+
+impl Parse for VariantDecl {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(VariantDecl {
+            attrs: Attribute::parse_outer(input)?,
+            inner: input.parse()?,
+        })
+    }
+}
+
+impl ToTokens for VariantDecl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        for attr in &self.attrs {
+            attr.to_tokens(tokens);
+        }
+        self.inner.to_tokens(tokens);
+    }
+}
+
+/// A message variant, represented as either an `enum` or a `struct`.
+enum VariantDeclInner {
+    Struct(ItemStruct),
+    Enum(ItemEnum),
+}
+
+impl ToTokens for VariantDeclInner {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        match self {
+            Self::Struct(ref s) => s.to_tokens(tokens),
+            Self::Enum(ref e) => e.to_tokens(tokens),
+        }
+    }
+}
+
+impl Parse for VariantDeclInner {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let vis: Token![pub] = input.parse()?;
+
+        let lookahead = input.lookahead1();
+        if lookahead.peek(Token![struct]) {
+            input.parse().map(|mut s: ItemStruct| {
+                s.vis = parse_quote! { #vis };
+                VariantDeclInner::Struct(s)
+            })
+        } else if lookahead.peek(Token![enum]) {
+            input.parse().map(|mut e: ItemEnum| {
+                e.vis = parse_quote! { #vis };
+                VariantDeclInner::Enum(e)
+            })
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
+/// Generate the message kind enumeration.
+fn generate_message_kind_type(decl: &MessageDecl) -> proc_macro2::TokenStream {
+    let kind_ty = &decl.kind_ty.ident;
+    let kind_ty_attr = &decl.kind_ty.attrs;
+    let variant = decl.variants.iter().map(|variant| match variant.inner {
+        VariantDeclInner::Struct(ref s) => &s.ident,
+        VariantDeclInner::Enum(ref e) => &e.ident,
+    });
+
+    quote! {
+        #(#kind_ty_attr)*
+        #[derive(Clone, Copy, Debug, Display, Eq, PartialEq)]
+        pub enum #kind_ty {
+            #(#variant,)*
+        }
+    }
+}
+
+/// Generate the message enumeration.
+fn generate_message_type(decl: &MessageDecl) -> proc_macro2::TokenStream {
+    let kind_ty = &decl.kind_ty.ident;
+    let msg_ty = &decl.msg_ty.ident;
+    let msg_ty_attr = &decl.msg_ty.attrs;
+    let variant = decl.variants.iter().map(|variant| match variant.inner {
+        VariantDeclInner::Struct(ref s) => &s.ident,
+        VariantDeclInner::Enum(ref e) => &e.ident,
+    });
+
+    let msg_ty_variant = decl.variants.iter().map(|variant| {
+        let ident = match variant.inner {
+            VariantDeclInner::Struct(ref s) => &s.ident,
+            VariantDeclInner::Enum(ref e) => &e.ident,
+        };
+
+        let doc = variant
+            .attrs
+            .iter()
+            .filter(|attr| match attr.parse_meta().ok() {
+                Some(Meta::NameValue(ref kv)) => kv.path.is_ident("doc"),
+                _ => false,
+            });
+
+        quote! {
+            #(#doc)*
+            #ident(#ident),
+        }
+    });
+
+    quote! {
+        #(#msg_ty_attr)*
+        #[derive(Debug, Deserialize, Serialize)]
+        pub enum #msg_ty {
+            #(#msg_ty_variant)*
+        }
+
+        impl Message<'_> for #msg_ty {
+            type Kind = #kind_ty;
+
+            fn kind(&self) -> Self::Kind {
+                match self {
+                    #(Self::#variant(..) => #kind_ty::#variant,)*
+                }
+            }
+        }
+    }
+}
+
+/// Generate `From`, `TryFrom`, and `MessageContent` impls for the variants.
+fn generate_impls(decl: &MessageDecl) -> proc_macro2::TokenStream {
+    let msg_ty = &decl.msg_ty.ident;
+    let kind_ty = &decl.kind_ty.ident;
+
+    let variant = decl.variants.iter().map(|variant| match variant.inner {
+        VariantDeclInner::Struct(ref s) => &s.ident,
+        VariantDeclInner::Enum(ref e) => &e.ident,
+    });
+
+    quote! {
+        #(
+            impl ::std::convert::From<#variant> for #msg_ty {
+                fn from(m: #variant) -> Self {
+                    #msg_ty::#variant(m)
+                }
+            }
+
+            impl ::std::convert::TryFrom<#msg_ty> for #variant {
+                type Error = KindMismatch<#kind_ty>;
+
+                fn try_from(msg: #msg_ty) -> Result<Self, Self::Error> {
+                    #[allow(irrefutable_let_patterns)]
+                    if let #msg_ty::#variant(inner) = msg {
+                        Ok(inner)
+                    } else {
+                        Err(KindMismatch {
+                            expected: #kind_ty::#variant,
+                            actual: msg.kind(),
+                        })
+                    }
+                }
+            }
+
+            impl MessageContent<'_, #msg_ty, #kind_ty> for #variant {
+                fn kind() -> #kind_ty {
+                    #kind_ty::#variant
+                }
+            }
+        )*
+    }
+}


### PR DESCRIPTION
The new message implementation macro, `message_ty!`, is written as a
procedural macro to make the maintenance burden easier. Declarative
macros may be conceptually simpler, but attempting to make
`impl_message!` work for either `struct` or `enum` members was *hard*
and got very messy very fast.

Additionally [rust#22694][rust22694] prevents using declarative macros
to generate item fragments (e.g., enum variants inside `enum Foo {}`),
which makes creating a maintainable decl macro quite hard.

It ended up being less effort to both rewrite it as a proc macro and
also add support for `enum` members. As a side effect, this macro
provides better error spans when it is provided with invalid input
(instead of the generic `no rules expected the token {token}` error).

[rust22694]: https://github.com/rust-lang/rust/issues/22694