### PR TITLE
Disable updates for downloaded Firefoxen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "futures",
+ "indoc",
  "libfxrecord",
  "mockito",
  "rand",

--- a/fxrecorder/src/lib/proto.rs
+++ b/fxrecorder/src/lib/proto.rs
@@ -84,6 +84,11 @@ impl RecorderProto {
             }
         }
 
+        if let DisableUpdates { result: Err(e) } = self.recv().await? {
+            error!(self.log, "Runner could not disable updates"; "error" => %e);
+            return Err(e.into());
+        }
+
         if let Some(profile_path) = profile_path {
             self.send_profile(profile_path, profile_size.unwrap())
                 .await?

--- a/fxrunner/Cargo.toml
+++ b/fxrunner/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/bin/main.rs"
 [dependencies]
 async-trait = "0.1.36"
 futures = "0.3.5"
+indoc = "0.3.6"
 libfxrecord = { path = "../libfxrecord" }
 rand = "0.7.3"
 reqwest =  { version = "0.10.6", features = ["json"] }

--- a/libfxrecord/src/net/message.rs
+++ b/libfxrecord/src/net/message.rs
@@ -156,6 +156,11 @@ message_type! {
         pub result: ForeignResult<DownloadStatus>,
     }
 
+    /// The status of the disable updates phase.
+    pub struct DisableUpdates {
+        pub result: ForeignResult<()>,
+    }
+
     /// The status of the RecvProfile phase.
     pub struct RecvProfile {
         pub result: ForeignResult<DownloadStatus>,


### PR DESCRIPTION
After downloading a build of Firefox, we disable the update via the
updater via the Policy Engine.