### PR TITLE
Overhaul logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "slog",
+ "slog-term",
  "tempfile",
  "tokio",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,13 +163,15 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.11"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
+ "libc",
  "num-integer",
  "num-traits",
  "time",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -747,6 +749,7 @@ name = "libfxrecord"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
+ "chrono",
  "derive_more",
  "futures",
  "indoc",

--- a/README.md
+++ b/README.md
@@ -100,3 +100,17 @@ host = "0.0.0.0:8888"
 ```
 
 An [example configuration](fxrecord.example.toml) is provided.
+
+## Testing
+
+To run the unit tests, run `cargo test`.
+
+The integration tests support logging, but by default cargo captures test
+output and runs tests in parallel. To have logs associated with tests
+clearly, run:
+
+```sh
+cargo test -p integration-tests -- --nocapture --test-threads 1
+```
+
+to force unit tests to run sequentially.

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -20,6 +20,7 @@ indoc = "0.3.6"
 reqwest = "0.10.6"
 serde_json = "1.0.55"
 slog = "2.5.2"
+slog-term = "2.5.0"
 tempfile = "3.1.0"
 tokio = { version = "0.2.21", features = ["dns", "fs", "io-util", "macros", "rt-threaded", "tcp"] }
 url = "2.1.1"

--- a/integration-tests/src/logging.rs
+++ b/integration-tests/src/logging.rs
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::fmt;
+use std::io;
+
+use slog::{o, Logger, OwnedKVList, Record};
+use slog_term::{Decorator, RecordDecorator};
+
+/// Generate loggers for testing.
+///
+/// The loggers are prepended with the process type.
+pub fn build_test_loggers() -> (Logger, Logger) {
+    use slog::Drain;
+
+    let runner_decorator = ProcessDecorator {
+        inner: slog_term::PlainSyncDecorator::new(slog_term::TestStdoutWriter),
+        process: Process::Runner,
+    };
+
+    let recorder_decorator = ProcessDecorator {
+        inner: slog_term::PlainSyncDecorator::new(slog_term::TestStdoutWriter),
+        process: Process::Recorder,
+    };
+
+    let runner_drain = slog_term::FullFormat::new(runner_decorator).build().fuse();
+    let recorder_drain = slog_term::FullFormat::new(recorder_decorator)
+        .build()
+        .fuse();
+
+    (
+        Logger::root(runner_drain, o! {}),
+        Logger::root(recorder_drain, o! {}),
+    )
+}
+
+enum Process {
+    Runner,
+    Recorder,
+}
+impl fmt::Display for Process {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Process::Runner => "runner".fmt(f),
+            Process::Recorder => "recorder".fmt(f),
+        }
+    }
+}
+
+struct ProcessDecorator<D> {
+    inner: D,
+    process: Process,
+}
+
+impl<D> Decorator for ProcessDecorator<D>
+where
+    D: Decorator,
+{
+    fn with_record<F>(&self, record: &Record, logger_values: &OwnedKVList, f: F) -> io::Result<()>
+    where
+        F: FnOnce(&mut dyn RecordDecorator) -> io::Result<()>,
+    {
+        self.inner
+            .with_record(record, logger_values, |record_decorator| {
+                record_decorator.reset()?;
+                write!(record_decorator, "[{:8}] ", self.process)?;
+                f(record_decorator)
+            })
+    }
+}

--- a/libfxrecord/Cargo.toml
+++ b/libfxrecord/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "MPL-2.0"
 
 [dependencies]
+chrono = "0.4.18"
 derive_more = "0.99.7"
 futures = "0.3.5"
 libfxrecord_macros = { path = "../libfxrecord_macros" }

--- a/libfxrecord/src/logging.rs
+++ b/libfxrecord/src/logging.rs
@@ -6,7 +6,10 @@ use slog::{Drain, Logger};
 
 /// Create a logger.
 pub fn build_logger() -> Logger {
-    let decorator = slog_term::PlainDecorator::new(std::io::stdout());
+    let decorator = slog_term::TermDecorator::new()
+        .stdout()
+        .force_plain()
+        .build();
     let drain = slog_term::FullFormat::new(decorator)
         .use_original_order()
         .use_utc_timestamp()

--- a/libfxrecord/src/logging.rs
+++ b/libfxrecord/src/logging.rs
@@ -2,21 +2,194 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use slog::{Drain, Logger};
+use std::fmt;
+use std::io;
+
+use chrono::Utc;
+use slog::{Drain, Key, Logger, OwnedKVList, Record, Serializer, KV};
+use slog_term::{Decorator, RecordDecorator, TermDecorator};
+
+// RFC3339 timestamp with millisecond precision.
+const TIMESTAMP_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.3fZ";
 
 /// Create a logger.
 pub fn build_logger() -> Logger {
-    let decorator = slog_term::TermDecorator::new()
-        .stdout()
-        .force_plain()
-        .build();
-    let drain = slog_term::FullFormat::new(decorator)
-        .use_original_order()
-        .use_utc_timestamp()
-        .build()
-        .fuse();
+    let decorator = TermDecorator::new().stdout().force_plain().build();
+    let drain = MultiLineDrain { decorator }.fuse();
 
     let drain = slog_async::Async::new(drain).build().fuse();
 
     Logger::root(drain, slog::o! {})
+}
+
+/// A drain that serializes each key-value pair on their own line, indented from
+/// the logged message.
+struct MultiLineDrain<D> {
+    decorator: D,
+}
+
+impl<D> Drain for MultiLineDrain<D>
+where
+    D: Decorator,
+{
+    type Ok = ();
+    type Err = io::Error;
+
+    fn log(&self, record: &Record, values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
+        self.decorator
+            .with_record(record, values, |record_decorator| {
+                record_decorator.start_timestamp()?;
+                write!(record_decorator, "{}", Utc::now().format(TIMESTAMP_FORMAT))?;
+
+                record_decorator.start_whitespace()?;
+                write!(record_decorator, " ")?;
+
+                record_decorator.start_level()?;
+                write!(record_decorator, "{}", record.level().as_str())?;
+
+                record_decorator.start_whitespace()?;
+                write!(record_decorator, " ")?;
+
+                record_decorator.start_msg()?;
+                write!(record_decorator, "{}", record.msg())?;
+
+                record_decorator.start_whitespace()?;
+                writeln!(record_decorator)?;
+
+                let mut serializer = MultiLineSerializer { record_decorator };
+                record.kv().serialize(record, &mut serializer)?;
+                values.serialize(record, &mut serializer)?;
+
+                Ok(())
+            })
+    }
+}
+
+/// A serializer that writes each key-value pair on its own line.
+///
+/// Mutliline strings are formatted indented from the key.
+struct MultiLineSerializer<'a> {
+    record_decorator: &'a mut dyn RecordDecorator,
+}
+
+impl<'a> MultiLineSerializer<'a> {
+    /// Emit the key of a key-value pair.
+    fn emit_key(&mut self, key: Key) -> Result<(), slog::Error> {
+        self.record_decorator.start_whitespace()?;
+        write!(self.record_decorator, "  ")?;
+        self.record_decorator.start_key()?;
+        write!(self.record_decorator, "{}", key)?;
+        self.record_decorator.start_separator()?;
+        write!(self.record_decorator, ":")?;
+
+        Ok(())
+    }
+
+    /// Emit a displayable value.
+    fn emit<D>(&mut self, key: Key, val: D) -> Result<(), slog::Error>
+    where
+        D: fmt::Display,
+    {
+        self.emit_key(key)?;
+        self.record_decorator.start_whitespace()?;
+        write!(self.record_decorator, " ")?;
+        self.record_decorator.start_value()?;
+        write!(self.record_decorator, "{}", val)?;
+        self.record_decorator.start_whitespace()?;
+        writeln!(self.record_decorator)?;
+
+        Ok(())
+    }
+
+    /// Emit a multi-line string value.
+    fn emit_lines(&mut self, key: Key, val: &str) -> Result<(), slog::Error> {
+        self.emit_key(key)?;
+        self.record_decorator.start_whitespace()?;
+        writeln!(self.record_decorator)?;
+
+        for line in val.lines() {
+            self.record_decorator.start_whitespace()?;
+            write!(self.record_decorator, "    ")?;
+            self.record_decorator.start_value()?;
+            write!(self.record_decorator, "{}", line)?;
+            self.record_decorator.start_whitespace()?;
+            writeln!(self.record_decorator)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Serializer for MultiLineSerializer<'a> {
+    fn emit_arguments(&mut self, key: Key, val: &fmt::Arguments) -> Result<(), slog::Error> {
+        self.emit(key, val)
+    }
+
+    fn emit_usize(&mut self, key: Key, val: usize) -> Result<(), slog::Error> {
+        self.emit(key, val)
+    }
+
+    fn emit_isize(&mut self, key: Key, val: isize) -> Result<(), slog::Error> {
+        self.emit(key, val)
+    }
+
+    fn emit_bool(&mut self, key: Key, val: bool) -> Result<(), slog::Error> {
+        self.emit(key, val)
+    }
+
+    fn emit_u8(&mut self, key: Key, val: u8) -> Result<(), slog::Error> {
+        self.emit(key, val)
+    }
+
+    fn emit_i8(&mut self, key: Key, val: i8) -> Result<(), slog::Error> {
+        self.emit(key, val)
+    }
+
+    fn emit_u16(&mut self, key: Key, val: u16) -> Result<(), slog::Error> {
+        self.emit(key, val)
+    }
+
+    fn emit_i16(&mut self, key: Key, val: i16) -> Result<(), slog::Error> {
+        self.emit(key, val)
+    }
+
+    fn emit_u32(&mut self, key: Key, val: u32) -> Result<(), slog::Error> {
+        self.emit(key, val)
+    }
+
+    fn emit_i32(&mut self, key: Key, val: i32) -> Result<(), slog::Error> {
+        self.emit(key, val)
+    }
+
+    fn emit_f32(&mut self, key: Key, val: f32) -> Result<(), slog::Error> {
+        self.emit(key, val)
+    }
+
+    fn emit_u64(&mut self, key: Key, val: u64) -> Result<(), slog::Error> {
+        self.emit(key, val)
+    }
+
+    fn emit_i64(&mut self, key: Key, val: i64) -> Result<(), slog::Error> {
+        self.emit(key, val)
+    }
+
+    fn emit_f64(&mut self, key: Key, val: f64) -> Result<(), slog::Error> {
+        self.emit(key, val)
+    }
+
+    fn emit_str(&mut self, key: Key, val: &str) -> Result<(), slog::Error> {
+        if val.contains('\n') {
+            self.emit_lines(key, val)
+        } else {
+            self.emit(key, val)
+        }
+    }
+
+    fn emit_unit(&mut self, key: Key) -> Result<(), slog::Error> {
+        self.emit(key, "()")
+    }
+
+    fn emit_none(&mut self, key: Key) -> Result<(), slog::Error> {
+        self.emit(key, "None")
+    }
 }


### PR DESCRIPTION
We now have a logger inside integration-tests to ease test debugging.  Additionally, our logging calls no longer lock the global stdout mutex when possible and write to the raw fd directly.

A custom drain has been added to print key-value pairs on separate lines to make output of multi-line values more readable.