### PR TITLE
Fix idle CPU detection

### DIFF
--- a/fxrecorder/src/lib/recorder.rs
+++ b/fxrecorder/src/lib/recorder.rs
@@ -95,6 +95,7 @@ impl<'a> Recorder for FfmpegRecorder<'a> {
         let framerate_arg = self.config.frame_rate.to_string();
 
         let mut args: Vec<&OsStr> = vec![
+            OsStr::new("-y"), // Always overwrite files that exist.
             OsStr::new("-f"),
             OsStr::new("dshow"),
             OsStr::new("-i"),

--- a/fxrunner/src/lib/proto.rs
+++ b/fxrunner/src/lib/proto.rs
@@ -536,8 +536,6 @@ where
                     }
                 };
 
-                info!(self.log, "child_process()"; "handle" => ?firefox_main_handle.as_ptr());
-
                 if let Err(e) = terminate_process(&firefox_main_handle, 1) {
                     error!(self.log, "could not terminate Firefox main process"; "error" => %e);
                     errors.push(e.into_error_message());

--- a/fxrunner/src/lib/splash.rs
+++ b/fxrunner/src/lib/splash.rs
@@ -71,6 +71,10 @@ impl Splash for WindowsSplash {
             let thread_id = unsafe { processthreadsapi::GetCurrentThreadId() };
             tx.send(Ok(thread_id)).unwrap();
 
+            unsafe {
+                winuser::SetCursorPos(display_width as i32, display_height as i32);
+            }
+
             run_message_loop(window_handle);
         });
 

--- a/integration-tests/src/mocks.rs
+++ b/integration-tests/src/mocks.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use libfxrecord::error::ErrorMessage;
 use libfxrecorder::recorder::Recorder;
-use libfxrunner::osapi::{IoCounters, PerfProvider, ShutdownProvider};
+use libfxrunner::osapi::{CpuTimes, IoCounters, PerfProvider, ShutdownProvider};
 use libfxrunner::session::{
     NewSessionError, ResumeSessionError, ResumeSessionErrorKind, SessionInfo, SessionManager,
 };
@@ -175,13 +175,16 @@ impl PerfProvider for TestPerfProvider {
         }
     }
 
-    fn get_cpu_idle_time(&self) -> Result<f64, Self::CpuTimeError> {
+    fn get_cpu_usage_time(&self) -> Result<CpuTimes, Self::CpuTimeError> {
         self.invoked();
 
         match self.failure_mode {
             Some(PerfFailureMode::CpuTimeError(s)) => Err(ErrorMessage(s)),
-            Some(PerfFailureMode::CpuNeverIdle) => Ok(0f64),
-            _ => Ok(0.99f64),
+            Some(PerfFailureMode::CpuNeverIdle) => Ok(CpuTimes { idle: 0, total: 1 }),
+            _ => Ok(CpuTimes {
+                idle: 99,
+                total: 100,
+            }),
         }
     }
 }


### PR DESCRIPTION
The main point of these changes is to fix how we detect idle CPU (before we were measuring overall idle% since startup, not local idle time). I've also fixed a few things I've run into while debugging this.