### PR TITLE
Provide fxrunner host as a string

### DIFF
--- a/fxrecorder/src/bin/main.rs
+++ b/fxrecorder/src/bin/main.rs
@@ -131,7 +131,7 @@ async fn record(
 
     let session_id = {
         let stream = TcpStream::connect(&config.host).await?;
-        info!(log, "Connected"; "peer" => config.host);
+        info!(log, "Connected"; "peer" => &config.host);
 
         // TODO: Ideally we would split new_session and resume_session into
         //       static methods so that we do not need to specify the recorder here.
@@ -170,7 +170,7 @@ async fn record(
                 e
             })?;
 
-        info!(log, "Re-connected"; "peer" => config.host);
+        info!(log, "Re-connected"; "peer" => &config.host);
 
         let mut proto = RecorderProto::new(
             log.clone(),

--- a/fxrecorder/src/lib/config.rs
+++ b/fxrecorder/src/lib/config.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -11,7 +10,7 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 pub struct Config {
     /// The address of the `fxrunner` to connect to.
-    pub host: SocketAddr,
+    pub host: String,
 
     /// The path to the `visualmetrics.py` script.
     pub visual_metrics_path: PathBuf,


### PR DESCRIPTION
This allows us to specify a hostname instead of just an IP address.