### PR TITLE
Fix TestPerfProvider to return increasing cpu times

### DIFF
--- a/fxrunner/src/lib/osapi/perf.rs
+++ b/fxrunner/src/lib/osapi/perf.rs
@@ -85,7 +85,7 @@ pub(super) fn get_disk_io_counters() -> Result<IoCounters, DiskIoError> {
 }
 
 /// Information about the idle time of a CPU in an interval.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct CpuTimes {
     /// The amount of time the CPU was idle in the interval (in arbitrary units).
     pub idle: u64,


### PR DESCRIPTION
When `cpu_and_disk_idle()` was updated to compute the cpu idle time over
an interval, the tests were never updated to match. This fixes those
tests.