### PR TITLE
Fix Display impl for ConfigError

### DIFF
--- a/libfxrecord/src/config.rs
+++ b/libfxrecord/src/config.rs
@@ -70,7 +70,7 @@ pub enum ConfigError {
     },
 
     /// The file could not be parsed.
-    #[error("Could not parse config file `{}': {}", "path.display()", .source)]
+    #[error("Could not parse config file `{}': {}", .path.display(), .source)]
     Parse {
         path: PathBuf,
         source: toml::de::Error,


### PR DESCRIPTION
The Display impl for ConfigError was showing "path.display()" instead of
the result of `self.path.display()`.