### PR TITLE
Minor fixups

### DIFF
--- a/contrib/Deploy.ps1
+++ b/contrib/Deploy.ps1
@@ -66,7 +66,7 @@ try {
 
     Write-Host Copying configuration...
 
-    $configFile = "contrib\config\${HostName}\fxrecord.toml"
+    $configFile = "config\${HostName}\fxrecord.toml"
     if (Test-Path $configFile) {
         if ($MachineType -eq "runner") {
             Copy-Item -Force -Path $configFile -ToSession $session -Destination C:\fxrunner\

--- a/contrib/deployment/config/fxrecorder01.corp.tor1.mozilla.com/fxrecord.toml
+++ b/contrib/deployment/config/fxrecorder01.corp.tor1.mozilla.com/fxrecord.toml
@@ -1,6 +1,6 @@
 [fxrecorder]
 host = "fxrunner01.corp.tor1.mozilla.com:8888"
-visual_metrics_path = "C:\\fxrecorder\\fxrecord.toml"
+visual_metrics_path = "C:\\fxrecorder\\vendor\\visualmetrics.py"
 
 [fxrecorder.recording]
 video_size = { x = 1920, y = 1080 }

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -32,9 +32,3 @@ See the :doc:`deployment` section for details on installation in a production se
 .. _imagemagick: https://legacy.imagemagick.org/
 .. _gc551: https://www.avermedia.com/us/product-detail/GC551
 .. _hd60s: https://www.elgato.com/en/game-capture-hd60-s
-
-
-fxrunner
---------
-
-fxrunner requires the following


### PR DESCRIPTION
The docs had an empty section (fxrunner has no additional reqs) and the visual metrics path in the deployment config was bogus.